### PR TITLE
List file extensions in Prolog.tmLanguage for PyCharm support

### DIFF
--- a/Syntaxes/Prolog.tmLanguage
+++ b/Syntaxes/Prolog.tmLanguage
@@ -3,7 +3,11 @@
 <plist version="1.0">
 <dict>
 	<key>fileTypes</key>
-	<array/>
+	<array>
+        	<string>pl</string>
+        	<string>pro</string>
+        	<string>prolog</string>
+   	</array>
 	<key>keyEquivalent</key>
 	<string>^~P</string>
 	<key>name</key>


### PR DESCRIPTION
It is needed to list the file extensions to make PyCharm highlight the syntax when it uses the TextMate bundle.